### PR TITLE
[Feature/chat soket connect] 팀메인 api 연결 및 하드코딩 수정

### DIFF
--- a/src/api/teamApi.ts
+++ b/src/api/teamApi.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const fetchTeam = async (teamId: number) => {
+    const res = await axios.get(`http://3.39.135.118:8080/api/teams/${teamId}`);
+    return res.data;
+  };

--- a/src/css/teamain/TeamMain.module.scss
+++ b/src/css/teamain/TeamMain.module.scss
@@ -109,7 +109,7 @@ aside{
     font-weight: 700;
 }
 .member_list{
-    height: 20vh;
+    height: 30vh;
     overflow: hidden;
     overflow-y: scroll;
 }

--- a/src/pages/coding-test/hooks/useCodingTestLogic.ts
+++ b/src/pages/coding-test/hooks/useCodingTestLogic.ts
@@ -6,7 +6,7 @@ export const useCodingTestLogic = () => {
   const [output, setOutput] = useState<string>('');
   const [isRunning, setIsRunning] = useState<boolean>(false);
   // TODO: 실제 타이머 로직 구현 필요
-  const [remainingTime, setRemainingTime] = useState<string>('1:48:54');
+  const [remainingTime, _setRemainingTime] = useState<string>('1:48:54');
   const [selectedLanguage, setSelectedLanguage] = useState<CodeLanguage>('python');
   const [codeContent, setCodeContent] = useState<Record<CodeLanguage, string>>({
     python: defaultCode.python,

--- a/src/pages/common/Header.tsx
+++ b/src/pages/common/Header.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from "@/css/main/Layout.module.scss";
 import Burger from "@/assets/burger.svg";
 

--- a/src/pages/common/Landing.tsx
+++ b/src/pages/common/Landing.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from '@/css/login/Auth.module.scss';
 
 const Landing = () => {

--- a/src/pages/history/Chat.tsx
+++ b/src/pages/history/Chat.tsx
@@ -28,7 +28,7 @@ function Chat() {
   // 아이디
   const myId = raw ? Number(JSON.parse(raw).userId) : null;
   // 채팅룸 id
-  const roomId = useSelector((state: RootState) => state.teamain.teamId);;
+  const roomId = useSelector((state: RootState) => state.teamain.teamId);
 
   useEffect(() => {
     if (!token || roomId === null) {

--- a/src/pages/history/Chat.tsx
+++ b/src/pages/history/Chat.tsx
@@ -27,12 +27,12 @@ function Chat() {
   const token = raw ? JSON.parse(JSON.parse(raw).token) : null;
   // 아이디
   const myId = raw ? Number(JSON.parse(raw).userId) : null;
-  
-  const roomId = 1;
+  // 채팅룸 id
+  const roomId = useSelector((state: RootState) => state.teamain.teamId);;
 
   useEffect(() => {
-    if (!token) {
-      console.warn('No token available');
+    if (!token || roomId === null) {
+      console.warn('No token available , roomId is null');
       return;
     }
 

--- a/src/pages/history/Chat.tsx
+++ b/src/pages/history/Chat.tsx
@@ -19,7 +19,7 @@ function Chat() {
   // 코드 관리 - 내가 채팅 보내기
   // const [messages, setMessages] = useState<ChatType[]>(ChatDummy);
   const [messages, setMessages] = useState<ChatType[]>([]);
-  const [connected, setConnected] = useState(false);
+  const [_connected, setConnected] = useState(false);
 
   // 로컬스토리지의 회원 정보 받아오기
   const raw = localStorage.getItem('persist:auth');

--- a/src/pages/history/chatbubble/BubbleChatbot.tsx
+++ b/src/pages/history/chatbubble/BubbleChatbot.tsx
@@ -3,8 +3,9 @@
 import styles from '@/css/history/Chat.module.scss'
 import { formatTime } from '@/pages/history/chatbubble/formatTime';
 
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { showTeamViewer } from '@/store/history/uiSlice';
+import { RootState } from '@/store';
 
 import { fetchProblemList } from '@/api/historyApi';
 import { setProblems } from '@/store/history/problemSlice';
@@ -19,15 +20,15 @@ export default function BubbleChatbot({ content, send_at, test_date }: Props) {
   
   const dispatch = useDispatch();
   const lines = content.split('\n');
+  const teamId = useSelector((state: RootState) => state.teamain.teamId);
 
   const handleClickShowProblems = async () => {
-    if (!test_date) {
+    if (!test_date || teamId === null) {
       console.warn('⚠️ 잘못된 요청경로로 인해 문제를 조회할 수 없습니다. (test_date가 null)');
       return;
     }
 
     try {
-      const teamId = 1; // 😻야강세진 : 여기 하드코딩이라 수정 필요
       const res = await fetchProblemList(teamId, test_date);
       dispatch(setProblems(res.data)); // 문제 리스트 저장
       dispatch(showTeamViewer()); // 왼쪽 컴포넌트 여는 리덕스 상태관리

--- a/src/pages/history/chatbubble/BubbleChatbot.tsx
+++ b/src/pages/history/chatbubble/BubbleChatbot.tsx
@@ -1,5 +1,4 @@
 // 챗봇 말풍선
-// import React from 'react'
 import styles from '@/css/history/Chat.module.scss'
 import { formatTime } from '@/pages/history/chatbubble/formatTime';
 

--- a/src/pages/history/codeeditor/hooks/useHighlights.tsx
+++ b/src/pages/history/codeeditor/hooks/useHighlights.tsx
@@ -7,11 +7,12 @@ import {
   Highlight,
   ActiveMemoState,
   UseHighlightsProps,
-  HighlightMenuState
+  // HighlightMenuState
 } from '@/pages/history/codeeditor/types/types.ts';
 
 // 유틸리티 임포트
-import { hexToRgba, rgbaToHex } from '@/pages/history/codeeditor/utils/colorUtils.ts';
+import { hexToRgba } from '@/pages/history/codeeditor/utils/colorUtils.ts';
+// import { hexToRgba, rgbaToHex } from '@/pages/history/codeeditor/utils/colorUtils.ts';
 import { calculateMemoPosition } from '@/pages/history/codeeditor/utils/domUtils.ts';
 
 // CodeMirror 확장 임포트
@@ -446,7 +447,12 @@ export function useHighlights({ documentId, editorRef, onHighlightClick }: UseHi
     });
 
     // 리스너 등록
-    const extension = view.dispatch({
+    // const extension = view.dispatch({
+    //   effects: StateEffect.appendConfig.of(docChangeListener)
+    // });
+
+    // 임의로 변수명 제거했습니다
+    view.dispatch({
       effects: StateEffect.appendConfig.of(docChangeListener)
     });
 

--- a/src/pages/main/MainNoTeam.tsx
+++ b/src/pages/main/MainNoTeam.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect } from 'react';
 import Header from '@/pages/common/Header.tsx';
-import SearchBox from '@/pages/main/component/SearchBox.tsx';
+// import SearchBox from '@/pages/main/component/SearchBox.tsx';
 import styles from "@/css/main/Layout.module.scss";
 import { AxiosResponse } from 'axios';
 import API from '@/store/api/ApiConfig.ts';
 import { teamDataResponse } from '@/pages/main/MainNoTeam.interface.ts';
-import FilterOrder from '@/pages/main/component/FilterOrder.tsx';
-import FilterQuestion from '@/pages/main/component/FilterQuestion.tsx';
+// import FilterOrder from '@/pages/main/component/FilterOrder.tsx';
+// import FilterQuestion from '@/pages/main/component/FilterQuestion.tsx';
 import TeamHeader from '@/pages/main/component/TeamHeader.tsx';
 import TeamDetail from '@/pages/main/TeamDialog/TeamDetail.tsx';
 
@@ -25,9 +25,9 @@ const MainNoTeam = () => {
   const [isOpenDialog, setIsOpenDialog] = React.useState(false);
   // const [teamList, setTeamList] = React.useState([]);
   const [teamList, setTeamList] = React.useState(mainTeamData);
-  const [selectedIndex, setSelectedIndex] = React.useState('');
+  const [selectedIndex, setSelectedIndex] = React.useState<number>(0);
 
-  const handleOpenDialog = (index: string) => {
+  const handleOpenDialog = (index: number) => {
     setIsOpenDialog(true);
     setSelectedIndex(index);
   }

--- a/src/pages/main/TeamDialog/TeamCreate.tsx
+++ b/src/pages/main/TeamDialog/TeamCreate.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import styles from '@/css/main/Layout.module.scss';
 
-const TeamCreate = ({onClose}) => {
+const TeamCreate = ({onClose} : any) => {
   return (
     <div className={styles.backdrop} onClick={onClose}>
       팀 생성 갈긴다.

--- a/src/pages/main/TeamDialog/TeamDetail.tsx
+++ b/src/pages/main/TeamDialog/TeamDetail.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import styles from "@/css/main/Layout.module.scss";
 
-const TeamDetail = ({team, onClose}) => {
+const TeamDetail = ({team, onClose} : any) => {
   console.log("team",team);
   return (
     <div className={styles.backdrop} onClick={onClose}>

--- a/src/pages/main/component/FilterOrder.tsx
+++ b/src/pages/main/component/FilterOrder.tsx
@@ -14,7 +14,7 @@ const FilterOrder = () => {
   const [open, setOpen] = React.useState(false);
   const [selected, setSelected] = React.useState(options[0]);
 
-  const handleSelected = (option) => {
+  const handleSelected = (option : any) => {
     setSelected(option);
     setOpen(false);
   }

--- a/src/pages/main/component/FilterQuestion.tsx
+++ b/src/pages/main/component/FilterQuestion.tsx
@@ -13,7 +13,7 @@ const FilterQuestion = () => {
   const [open, setOpen] = React.useState(false);
   const [selected, setSelected] = React.useState(levels[0]);
 
-  const handleSelected = (option) => {
+  const handleSelected = (option : any) => {
     setSelected(option);
     setOpen(false);
   }

--- a/src/pages/teamain/TeamMain.tsx
+++ b/src/pages/teamain/TeamMain.tsx
@@ -1,5 +1,6 @@
 import styles from '@/css/teamain/TeamMain.module.scss'
 import hamburgerIcon from '@/assets/hamb.svg';
+import { teamDummy } from '@/pages/teamain/data/teamDummy';
 
 export default function TeamMain() {
   return (
@@ -13,21 +14,12 @@ export default function TeamMain() {
             <section className={styles.left_container}>
                 <section className={styles.container}>
                     <div className={styles.team_info}>
-                        <h2>프로그래모</h2>
-                        <p>매일 오후 9시 | 중 | 3문제 | 2시간</p>
+                        <h2>{teamDummy.teamName}</h2>
+                        <p>매일 오후 9시 | {teamDummy.level} | {teamDummy.problemCount}문제 | {teamDummy.durationTime}시간</p>
                     </div>
                     <div className={styles.team_des}>
                         <p>
-                        안녕하세요 “프로그램(Program)”과 “Memo(기억, 기록)”를 합쳐, <br/>
-                        함께 개발하며 기억에 남는 성과를 만들어가는  팀 “프로그래모(PrograMemo)” 입니다
-
-                        <br/>--------------------------------------- <br/>
-                        매일 9시 출석체크 채널에 출석 :  <br/>책상 사진 찍어서 올리기 ( 지각 9:10까지 인정 ) <br/>
-                        🚨 올리지 않을 경우 패널티 :  <br/>랜덤 추첨 1명에게  <br/> ☕️커피사기 (메가커피,컴포즈 등등..)
-                        <br/>---------------------------------------- <br/>
-                        시험 참여 3번 이상시 강퇴합니다.<br/>
-                        멧돌멧돌멧돌이노래를한다아기손자며느리다모여서<br/>
-                        멧돌멧돌멧돌이노래를한다아기손자며느리다모여서<br/>
+                        {teamDummy.description}
                         </p>
                     </div>
                 </section>
@@ -38,7 +30,11 @@ export default function TeamMain() {
             <aside className={styles.container}>
                 <div className={styles.right_container}>
                     <h2>참여멤버</h2>
-                    <h3> <span>6</span> / 10명</h3>
+                    <h3> <span>
+                        {teamDummy.currentMembers}
+                        </span> 
+                        / 10명
+                    </h3>
 
                     <button className={styles.history_button}>
                         히스토리
@@ -46,17 +42,15 @@ export default function TeamMain() {
 
                     <p>
                         <span>팀장</span> 
-                        김재홍
+                        {teamDummy.leader.userName}
                         <span role="img" aria-label="왕관">👑</span>
                     </p>
 
                     <p className={styles.teamtext}>팀원</p>
                     <div className={styles.member_list}>
-                        <p>강세진</p>
-                        <p>김건영</p>
-                        <p>김유림</p>
-                        <p>이보미</p>
-                        <p>심동훈</p>
+                        {teamDummy.members.map((member) => (
+                            <p key={member.userId}>{member.userName}</p>
+                        ))}
                     </div>
                 </div>
                 <button className={styles.exitbtn}>팀 탈퇴하기</button>

--- a/src/pages/teamain/TeamMain.tsx
+++ b/src/pages/teamain/TeamMain.tsx
@@ -3,6 +3,8 @@ import hamburgerIcon from '@/assets/hamb.svg';
 import { teamDummy } from '@/pages/teamain/data/teamDummy';
 
 export default function TeamMain() {
+    const leader = teamDummy.members.find((member) => member.userId === teamDummy.leaderId);
+
   return (
     <div className={styles.teamroom}>
         <header>
@@ -42,7 +44,7 @@ export default function TeamMain() {
 
                     <p>
                         <span>팀장</span> 
-                        {teamDummy.leader.userName}
+                        {leader?.userName}
                         <span role="img" aria-label="왕관">👑</span>
                     </p>
 

--- a/src/pages/teamain/TeamMain.tsx
+++ b/src/pages/teamain/TeamMain.tsx
@@ -22,7 +22,7 @@ export default function TeamMain() {
             .then(setTeamData)
             .catch((error) => console.log("님 에러났어여 ㅋ:", error));
         }
-    })
+    },[])
 
     if (!teamData) {
         return <div>재접속 plz 네트워크가 느려요잉~</div>;
@@ -31,6 +31,8 @@ export default function TeamMain() {
     const handleHistoryButtonClick = () => {
         navigate('/history');
     };
+
+    console.log(teamData)
 
     const leader = teamData.members.find((member) => member.userId === teamData.leaderId);
 

--- a/src/pages/teamain/TeamMain.tsx
+++ b/src/pages/teamain/TeamMain.tsx
@@ -5,8 +5,11 @@ import { TeamData } from '@/pages/teamain/types/TeamTypes';
 import styles from '@/css/teamain/TeamMain.module.scss'
 import hamburgerIcon from '@/assets/hamb.svg';
 
-export default function TeamMain() {
+import { useNavigate } from 'react-router-dom';
 
+export default function TeamMain() {
+    const navigate = useNavigate();
+    
     // 일단 1로 하드코딩
     const teamId = 1;
 
@@ -24,6 +27,10 @@ export default function TeamMain() {
     if (!teamData) {
         return <div>재접속 plz 네트워크가 느려요잉~</div>;
     }
+
+    const handleHistoryButtonClick = () => {
+        navigate('/history');
+    };
 
     const leader = teamData.members.find((member) => member.userId === teamData.leaderId);
 
@@ -60,7 +67,8 @@ export default function TeamMain() {
                         / 10명
                     </h3>
 
-                    <button className={styles.history_button}>
+                    <button className={styles.history_button}
+                        onClick={handleHistoryButtonClick}>
                         히스토리
                     </button>
 

--- a/src/pages/teamain/TeamMain.tsx
+++ b/src/pages/teamain/TeamMain.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { fetchTeam } from '@/api/teamApi';
 import { TeamData } from '@/pages/teamain/types/TeamTypes';
+import { useDispatch } from 'react-redux';
+import { setTeamId } from '@/store/team/teamainSlice';
 
 import styles from '@/css/teamain/TeamMain.module.scss'
 import hamburgerIcon from '@/assets/hamb.svg';
@@ -9,7 +11,8 @@ import { useNavigate } from 'react-router-dom';
 
 export default function TeamMain() {
     const navigate = useNavigate();
-    
+    const dispatch = useDispatch();
+
     // 일단 1로 하드코딩
     const teamId = 1;
 
@@ -19,7 +22,10 @@ export default function TeamMain() {
     useEffect(() => {
         if (teamId) {
             fetchTeam(teamId)
-            .then(setTeamData)
+            .then((data) => {
+                setTeamData(data);
+                dispatch(setTeamId(data.id));
+            })
             .catch((error) => console.log("님 에러났어여 ㅋ:", error));
         }
     },[])

--- a/src/pages/teamain/TeamMain.tsx
+++ b/src/pages/teamain/TeamMain.tsx
@@ -1,9 +1,31 @@
+import { useEffect, useState } from 'react';
+import { fetchTeam } from '@/api/teamApi';
+import { TeamData } from '@/pages/teamain/types/TeamTypes';
+
 import styles from '@/css/teamain/TeamMain.module.scss'
 import hamburgerIcon from '@/assets/hamb.svg';
-import { teamDummy } from '@/pages/teamain/data/teamDummy';
 
 export default function TeamMain() {
-    const leader = teamDummy.members.find((member) => member.userId === teamDummy.leaderId);
+
+    // 일단 1로 하드코딩
+    const teamId = 1;
+
+    // 팀 데이터 냅다 가져와서 상태관리해~ 레츠기릭
+    const [teamData, setTeamData] = useState<TeamData | null>(null);
+
+    useEffect(() => {
+        if (teamId) {
+            fetchTeam(teamId)
+            .then(setTeamData)
+            .catch((error) => console.log("님 에러났어여 ㅋ:", error));
+        }
+    })
+
+    if (!teamData) {
+        return <div>재접속 plz 네트워크가 느려요잉~</div>;
+    }
+
+    const leader = teamData.members.find((member) => member.userId === teamData.leaderId);
 
   return (
     <div className={styles.teamroom}>
@@ -16,12 +38,12 @@ export default function TeamMain() {
             <section className={styles.left_container}>
                 <section className={styles.container}>
                     <div className={styles.team_info}>
-                        <h2>{teamDummy.teamName}</h2>
-                        <p>매일 오후 9시 | {teamDummy.level} | {teamDummy.problemCount}문제 | {teamDummy.durationTime}시간</p>
+                        <h2>{teamData.teamName}</h2>
+                        <p>매일 오후 9시 | {teamData.level} | {teamData.problemCount}문제 | {teamData.durationTime}시간</p>
                     </div>
                     <div className={styles.team_des}>
                         <p>
-                        {teamDummy.description}
+                        {teamData.description}
                         </p>
                     </div>
                 </section>
@@ -33,7 +55,7 @@ export default function TeamMain() {
                 <div className={styles.right_container}>
                     <h2>참여멤버</h2>
                     <h3> <span>
-                        {teamDummy.currentMembers}
+                        {teamData.currentMembers}
                         </span> 
                         / 10명
                     </h3>
@@ -50,7 +72,7 @@ export default function TeamMain() {
 
                     <p className={styles.teamtext}>팀원</p>
                     <div className={styles.member_list}>
-                        {teamDummy.members.map((member) => (
+                        {teamData.members.map((member) => (
                             <p key={member.userId}>{member.userName}</p>
                         ))}
                     </div>

--- a/src/pages/teamain/data/teamDummy.ts
+++ b/src/pages/teamain/data/teamDummy.ts
@@ -1,26 +1,4 @@
-
-export interface Member {
-    userId: number;
-    userName: string;
-  }
-  
-  export interface Leader {
-    userId: number;
-    userName: string;
-  }
-  
-  export interface TeamData {
-    id: number;
-    teamName: string;
-    description: string;
-    level: string; 
-    problemCount: number;
-    startTime: string;
-    durationTime: number;
-    currentMembers: number;
-    leader: Leader;
-    members: Member[];
-  }
+import { TeamData } from '@/pages/teamain/types/TeamTypes'
 
 export const teamDummy: TeamData = {
     id: 1,
@@ -31,18 +9,16 @@ export const teamDummy: TeamData = {
     problemCount: 5,
     startTime: "2025-04-22T10:00",
     durationTime: 3,
-    currentMembers: 6,
-    leader: {
-      userId: 3,
-      userName: "거녕거녕"
-    },
+    currentMembers: 7,
+    leaderId: 3,
     members: [
-      { userId: 1, userName: "강세진" },
-      { userId: 2, userName: "김건영" },
-      { userId: 3, userName: "거녕거녕" },
-      { userId: 4, userName: "김유림" },
-      { userId: 5, userName: "이보미" },
-      { userId: 6, userName: "심동훈" }
+      { userId: 1, userName: "강세진", "leader": false },
+      { userId: 2, userName: "김건영", "leader": false },
+      { userId: 3, userName: "거녕거녕", "leader": true },
+      { userId: 4, userName: "김유림", "leader": false },
+      { userId: 5, userName: "이보미", "leader": false },
+      { userId: 6, userName: "심동훈", "leader": false },
+      { userId: 7, userName: "멧돌멧돌", "leader": false },
     ]
   };
   

--- a/src/pages/teamain/data/teamDummy.ts
+++ b/src/pages/teamain/data/teamDummy.ts
@@ -13,12 +13,11 @@ export interface Member {
     id: number;
     teamName: string;
     description: string;
-    level: 'EASY' | 'MEDIUM' | 'HARD'; // 서버 명세에 맞게
+    level: string; 
     problemCount: number;
     startTime: string;
     durationTime: number;
     currentMembers: number;
-    maxMembers: number;
     leader: Leader;
     members: Member[];
   }
@@ -33,7 +32,6 @@ export const teamDummy: TeamData = {
     startTime: "2025-04-22T10:00",
     durationTime: 3,
     currentMembers: 6,
-    maxMembers: 10,
     leader: {
       userId: 3,
       userName: "거녕거녕"

--- a/src/pages/teamain/data/teamDummy.ts
+++ b/src/pages/teamain/data/teamDummy.ts
@@ -1,0 +1,50 @@
+
+export interface Member {
+    userId: number;
+    userName: string;
+  }
+  
+  export interface Leader {
+    userId: number;
+    userName: string;
+  }
+  
+  export interface TeamData {
+    id: number;
+    teamName: string;
+    description: string;
+    level: 'EASY' | 'MEDIUM' | 'HARD'; // 서버 명세에 맞게
+    problemCount: number;
+    startTime: string;
+    durationTime: number;
+    currentMembers: number;
+    maxMembers: number;
+    leader: Leader;
+    members: Member[];
+  }
+
+export const teamDummy: TeamData = {
+    id: 1,
+    teamName: "멧도리도리팀",
+    description: `팀원 모두가 코딩테스트에 완벽하게 참여한 날에 멧돌이의 사진을 업데이트합니다.
+  귀여운 햄스터를 보고싶다면 지금 당장 공부하세요. 찍찍🐹`,
+    level: "EASY",
+    problemCount: 5,
+    startTime: "2025-04-22T10:00",
+    durationTime: 3,
+    currentMembers: 6,
+    maxMembers: 10,
+    leader: {
+      userId: 3,
+      userName: "거녕거녕"
+    },
+    members: [
+      { userId: 1, userName: "강세진" },
+      { userId: 2, userName: "김건영" },
+      { userId: 3, userName: "거녕거녕" },
+      { userId: 4, userName: "김유림" },
+      { userId: 5, userName: "이보미" },
+      { userId: 6, userName: "심동훈" }
+    ]
+  };
+  

--- a/src/pages/teamain/types/TeamTypes.ts
+++ b/src/pages/teamain/types/TeamTypes.ts
@@ -1,0 +1,18 @@
+export interface Member {
+    userId: number;
+    userName: string;
+    leader: boolean;
+}
+  
+export interface TeamData {
+    id: number;
+    teamName: string;
+    description: string;
+    level: string; 
+    problemCount: number;
+    startTime: string;
+    durationTime: number;
+    currentMembers: number;
+    leaderId: number;
+    members: Member[];
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,7 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from "@/store/auth/slices";
 import uiReducer from '@/store/history/uiSlice';
-import problemReducer from './history/problemSlice';
+import problemReducer from '@/store/history/problemSlice';
+import teamainReducer from '@/store/team/teamainSlice';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { persistStore, persistReducer, FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
@@ -18,7 +19,8 @@ export const store = configureStore({
   reducer: {
     auth: persistedAuthReducer,
     ui: uiReducer,
-    historyProblem: problemReducer
+    historyProblem: problemReducer,
+    teamain: teamainReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,14 +13,21 @@ const authPersistConfig = {
   whitelist: ['token', 'user', 'isLoggedIn', 'userId'],
 };
 
+const teamainPersistConfig = {
+  key: 'teamain',
+  storage,
+  whitelist: ['teamId'],
+};
+
 const persistedAuthReducer = persistReducer(authPersistConfig, authReducer);
+const persistedTeamainReducer = persistReducer(teamainPersistConfig, teamainReducer);
 
 export const store = configureStore({
   reducer: {
     auth: persistedAuthReducer,
     ui: uiReducer,
     historyProblem: problemReducer,
-    teamain: teamainReducer,
+    teamain: persistedTeamainReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/src/store/team/teamainSlice.ts
+++ b/src/store/team/teamainSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface TeamState {
+    teamId: number | null;
+}
+  
+const initialState: TeamState = {
+    teamId: null,
+};
+  
+const teamSlice = createSlice({
+    name: 'teamain',
+    initialState,
+    reducers: {
+        setTeamId: (state, action: PayloadAction<number>) => {
+            state.teamId = action.payload;
+        },
+        clearTeamId: (state) => {
+        state.teamId = null;
+        },
+    },
+});
+  
+export const { setTeamId, clearTeamId } = teamSlice.actions;
+export default teamSlice.reducer;


### PR DESCRIPTION
## 🔗 관련 이슈 번호 <!--- ex) 이슈 번호를 작성해주세요 close #11 -->

- Closes #이슈번호

## 🛠️ PR 유형
<!-- 어떤 변경 사항이 있나요? -->
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 작업 내용

- 메인 api 연결. 하드코딩 수정

<!-- 예: 로그인 UI 수정, API 연결, 유효성 검사 추가 등 -->

## ✅ 변경 사항

- 메인에서 팀 정보 가져온다음 리덕스에 팀 id 저장해서 소켓 요청 경로, 문제 요청 경로에 적용했스니다
  
<!-- 예: - UI 버튼 위치 변경
- 로그인 실패 시 에러 메시지 추가
- API 연결 시 토큰 헤더 포함  -->

## 📸 스크린샷 (선택)
  
## 💬 코멘트

- 그냥 냅다 리덕스에 팀 아이디 저장하게 한다음에 필요한곳에서 꺼내 쓰는데 이렇게 해도 되는지 모르겠네요.. 급해서 이렇게 하긴 했는데 맞는지두 모르겠구
- 그리고 이 팀 아이디도 로컬스토리지에 저장하는게 좋을지? 고민입니다. 
